### PR TITLE
Fix API model definitions and agent typo

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -74,7 +74,7 @@ yahoo_finance_agent = CustomToolCallingAgent(
     tools=[yahoo_finance_search],
     model=claude_llm,
     max_steps=5,
-    name="yeahoo_finance_search",
+    name="yahoo_finance_search",
     description="Use this tool to search for financial data for publicly traded companies. Input must be a ticker symbol. Example: 'AAPL'."
 )
 

--- a/main.py
+++ b/main.py
@@ -1,17 +1,15 @@
-import os
-import requests
-from typing import Union, Dict, Annotated
-from pydantic import BaseModel
+from typing import Annotated
+from pydantic import BaseModel, Field
 from fastapi import FastAPI
 
 from agent import manager_agent
 
 
 class TaskInput(BaseModel):
-    task: Annotated[str, ..., "The task to be performed"]
+    task: Annotated[str, Field(..., description="The task to be performed")]
 
 class TaskOutput(BaseModel):
-    output: Annotated[str, ..., "The result of the task"]
+    output: Annotated[str, Field(..., description="The result of the task")]
 
 
 app = FastAPI(title='Research Agents', version='0.1.0')


### PR DESCRIPTION
## Summary
- fix `TaskInput` and `TaskOutput` field declarations
- correct `yahoo_finance_agent` name typo

## Testing
- `python -m py_compile main.py agent.py tools.py`

------
https://chatgpt.com/codex/tasks/task_e_6844769e60c0832ca35ed531d01a3f05