### PR TITLE
Integrate GDELT API tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,22 @@ Optional web interface for interacting with the system, providing a user-friendl
 - 🔍 **Vector search**: Semantic search for curated newsletters on AI policy
 - 📚 **Academic research**: Integration with Arxiv for scientific papers
 - 💹 **Financial data**: Integration with Yahoo Finance for company information
+- 🌐 **GDELT access**: Query global event and entity data via GDELT v2/v3 APIs
+
+## 🌐 GDELT Integration
+
+```mermaid
+flowchart TD
+    Tool[Research Tools] --> GDELT[GDELT API]
+```
+
+
+```python
+from gdelt_v2 import query_doc
+res = await query_doc(query="Ukraine", start="20250101000000", end="20250102000000")
+```
+
+- [Official GDELT Documentation](https://www.gdeltproject.org/)
 
 ## 🚀 Getting Started
 
@@ -255,7 +271,7 @@ new_agent = CustomToolCallingAgent(
 manager_agent = CodeAgent(
     tools=[],
     model=claude_llm,
-    managed_agents=[web_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent, new_agent],
+    managed_agents=[web_search_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent, new_agent],
     additional_authorized_imports=["time", "numpy", "pandas"],
     planning_interval=2
 )

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,33 @@
+# 🛠️ Research Tools
+
+This document lists the available tools and their usage.
+
+## GDELT V2
+
+### `query_gdelt_v2_doc`
+```python
+query_gdelt_v2_doc(query: str, mode: str = "TimelineTone", start: str | None = None, end: str | None = None) -> dict
+```
+Queries the GDELT V2 DOC API and returns a dictionary of results.
+
+### `query_gdelt_v2_gkg`
+```python
+query_gdelt_v2_gkg(query: str, themes: list[str] | None = None) -> dict
+```
+Queries the GDELT V2 GKG API.
+
+## GDELT V3
+
+### `query_gdelt_v3_entities`
+```python
+query_gdelt_v3_entities(start: str, end: str, query: str) -> dict
+```
+Retrieves entity data from the experimental GDELT V3 API.
+
+### `query_gdelt_v3_events`
+```python
+query_gdelt_v3_events(start: str, end: str, query: str) -> dict
+```
+Retrieves event data from the experimental GDELT V3 API.
+
+

--- a/agent.py
+++ b/agent.py
@@ -46,11 +46,11 @@ claude_llm = LiteLLMModel(
 
 
 # Tool Calling Agents
-web_agent = CustomToolCallingAgent(
+web_search_agent = CustomToolCallingAgent(
     tools=[DuckDuckGoSearchTool(), VisitWebpageTool()],
     model=claude_llm,
     max_steps=5,
-    name="web_search",
+    name="web_search_agent",
     description="Runs web searches for you. Give it your query as an argument."
 )
 
@@ -83,7 +83,7 @@ yahoo_finance_agent = CustomToolCallingAgent(
 manager_agent = CodeAgent(
     tools=[],
     model=claude_llm,
-    managed_agents=[web_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent],
+    managed_agents=[web_search_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent],
     additional_authorized_imports=["time", "numpy", "pandas"],
     planning_interval=2
 )

--- a/gdelt_v2.py
+++ b/gdelt_v2.py
@@ -1,0 +1,89 @@
+import aiohttp
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+BASE_URL_V2 = "https://api.gdeltproject.org/api/v2"
+
+
+class TooManyRequests(Exception):
+    """Raised when the API rate limit is hit."""
+
+
+class RateLimiter:
+    def __init__(self, rate: float = 1.0) -> None:
+        self.rate = rate
+        self._lock = asyncio.Lock()
+        self._last_call = 0.0
+
+    async def __aenter__(self) -> None:
+        await self._lock.acquire()
+        wait_time = self._last_call + 1 / self.rate - asyncio.get_event_loop().time()
+        if wait_time > 0:
+            await asyncio.sleep(wait_time)
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        self._last_call = asyncio.get_event_loop().time()
+        self._lock.release()
+
+
+rate_limiter = RateLimiter()
+
+
+@dataclass
+class DocResponse:
+    articles: List[Dict[str, Any]] = field(default_factory=list)
+    total: Optional[int] = None
+
+
+@dataclass
+class GKGResponse:
+    gkg: List[Dict[str, Any]] = field(default_factory=list)
+    total: Optional[int] = None
+
+
+async def _request_json(endpoint: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    @retry(
+        retry=retry_if_exception_type(TooManyRequests),
+        wait=wait_exponential(multiplier=1, min=1, max=60),
+        stop=stop_after_attempt(3),
+        reraise=True,
+    )
+    async def _inner() -> Dict[str, Any]:
+        async with aiohttp.ClientSession() as session:
+            async with rate_limiter:
+                async with session.get(endpoint, params=params) as resp:
+                    if resp.status == 429:
+                        retry_after = int(resp.headers.get("Retry-After", "300"))
+                        await asyncio.sleep(retry_after)
+                        raise TooManyRequests()
+                    resp.raise_for_status()
+                    return await resp.json()
+
+    return await _inner()
+
+
+async def query_doc(
+    query: str,
+    mode: str = "TimelineTone",
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+) -> DocResponse:
+    params = {"query": query, "mode": mode, "format": "json"}
+    if start:
+        params["startdatetime"] = start
+    if end:
+        params["enddatetime"] = end
+    data = await _request_json(f"{BASE_URL_V2}/doc/doc", params)
+    return DocResponse(articles=data.get("articles", []), total=data.get("total"))
+
+
+async def query_gkg(query: str, themes: Optional[List[str]] = None) -> GKGResponse:
+    params = {"query": query, "format": "json"}
+    if themes:
+        params["query"] = query + " " + " ".join(themes)
+    data = await _request_json(f"{BASE_URL_V2}/gkg/gkg", params)
+    return GKGResponse(gkg=data.get("gkg", []), total=data.get("total"))
+

--- a/gdelt_v3.py
+++ b/gdelt_v3.py
@@ -1,0 +1,66 @@
+import aiohttp
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential
+
+from gdelt_v2 import RateLimiter, TooManyRequests
+
+BASE_URL_V3 = "https://api.gdeltproject.org/api/v3"
+
+rate_limiter = RateLimiter()
+
+
+@dataclass
+class EntityResponse:
+    entities: List[Dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class EventResponse:
+    events: List[Dict[str, Any]] = field(default_factory=list)
+
+
+async def _request_json(endpoint: str, params: Dict[str, Any]) -> Dict[str, Any]:
+    @retry(
+        retry=retry_if_exception_type(TooManyRequests),
+        wait=wait_exponential(multiplier=1, min=1, max=60),
+        stop=stop_after_attempt(3),
+        reraise=True,
+    )
+    async def _inner() -> Dict[str, Any]:
+        async with aiohttp.ClientSession() as session:
+            async with rate_limiter:
+                async with session.get(endpoint, params=params) as resp:
+                    if resp.status == 429:
+                        retry_after = int(resp.headers.get("Retry-After", "300"))
+                        await asyncio.sleep(retry_after)
+                        raise TooManyRequests()
+                    resp.raise_for_status()
+                    return await resp.json()
+
+    return await _inner()
+
+
+async def get_entities(start: str, end: str, query: str) -> EntityResponse:
+    params = {
+        "query": query,
+        "format": "json",
+        "startdatetime": start,
+        "enddatetime": end,
+    }
+    data = await _request_json(f"{BASE_URL_V3}/entities", params)
+    return EntityResponse(entities=data.get("entities", []))
+
+
+async def get_events(start: str, end: str, query: str) -> EventResponse:
+    params = {
+        "query": query,
+        "format": "json",
+        "startdatetime": start,
+        "enddatetime": end,
+    }
+    data = await _request_json(f"{BASE_URL_V3}/events", params)
+    return EventResponse(events=data.get("events", []))
+

--- a/poetry.lock
+++ b/poetry.lock
@@ -507,12 +507,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main"]
-markers = "platform_system == \"Windows\" or sys_platform == \"win32\""
+groups = ["main", "dev"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
+markers = {main = "platform_system == \"Windows\" or sys_platform == \"win32\"", dev = "sys_platform == \"win32\""}
 
 [[package]]
 name = "curl-cffi"
@@ -577,7 +577,7 @@ version = "1.3.0"
 description = "Backport of PEP 654 (exception groups)"
 optional = false
 python-versions = ">=3.7"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation == \"PyPy\" and python_version < \"3.11\" or python_version == \"3.10\""
 files = [
     {file = "exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10"},
@@ -1252,7 +1252,7 @@ version = "2.1.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760"},
     {file = "iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7"},
@@ -2493,7 +2493,7 @@ version = "24.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-24.2-py3-none-any.whl", hash = "sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"},
     {file = "packaging-24.2.tar.gz", hash = "sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f"},
@@ -2773,7 +2773,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -3100,7 +3100,7 @@ version = "2.19.1"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c"},
     {file = "pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f"},
@@ -3115,7 +3115,7 @@ version = "8.4.0"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.4.0-py3-none-any.whl", hash = "sha256:f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e"},
     {file = "pytest-8.4.0.tar.gz", hash = "sha256:14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6"},
@@ -3204,6 +3204,24 @@ rich = ">=13.8.1"
 compat = ["pytest-benchmark (>=5.0.0,<5.1.0)", "pytest-xdist (>=3.6.1,<3.7.0)"]
 lint = ["mypy (>=1.11.2,<1.12.0)", "ruff (>=0.6.5,<0.7.0)"]
 test = ["pytest (>=7.0,<8.0)", "pytest-cov (>=4.0.0,<4.1.0)"]
+
+[[package]]
+name = "pytest-mock"
+version = "3.14.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "pytest_mock-3.14.1-py3-none-any.whl", hash = "sha256:178aefcd11307d874b4cd3100344e7e2d888d9791a6a1d9bfe90fbc1b74fd1d0"},
+    {file = "pytest_mock-3.14.1.tar.gz", hash = "sha256:159e9edac4c451ce77a5cdb9fc5d1100708d2dd4ba3c3df572f14097351af80e"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
 name = "pytest-recording"
@@ -3989,7 +4007,7 @@ version = "2.2.1"
 description = "A lil' TOML parser"
 optional = false
 python-versions = ">=3.8"
-groups = ["main"]
+groups = ["main", "dev"]
 markers = "platform_python_implementation == \"PyPy\" and python_version < \"3.11\" or python_version == \"3.10\""
 files = [
     {file = "tomli-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:678e4fa69e4575eb77d103de3df8a895e1591b48e740211bd1067378c69e8249"},
@@ -4066,11 +4084,12 @@ version = "4.14.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
 optional = false
 python-versions = ">=3.9"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af"},
     {file = "typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4"},
 ]
+markers = {dev = "platform_python_implementation == \"PyPy\" and python_version < \"3.11\" or python_version == \"3.10\""}
 
 [[package]]
 name = "typing-inspect"
@@ -4649,4 +4668,4 @@ cffi = ["cffi (>=1.11)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10.0,<3.12"
-content-hash = "45459d88f3bb9de4e62d6d8ab0a6a25eebcab01ba41eb82dceb36ac28659e113"
+content-hash = "08a81bfb11241ee30ac8d893762f70c5ff412eb225870272f1b84195003d2593"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ arxiv = "^2.2.0"
 yfinance = "^0.2.61"
 google-search-results = "^2.4.2"
 langchain-fmp-data = "^0.1.0"
+aiohttp = "^3.9.5"
+tenacity = "^9.0.1"
 
 [tool.pyright]
 # https://github.com/microsoft/pyright/blob/main/docs/configuration.md
@@ -36,3 +38,6 @@ ignore = ['W291', 'W292', 'W293']
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.2.0"
+pytest-mock = "^3.12.0"

--- a/tests/unit/test_gdelt.py
+++ b/tests/unit/test_gdelt.py
@@ -1,0 +1,54 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+import gdelt_v2
+import gdelt_v3
+
+
+class DummyResponse:
+    def __init__(self, status: int, json_data: dict, headers: dict | None = None):
+        self.status = status
+        self._json = json_data
+        self.headers = headers or {}
+
+    async def json(self):
+        return self._json
+
+    def raise_for_status(self):
+        if self.status >= 400:
+            raise Exception("HTTP error")
+
+
+class DummyContext:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_query_doc_success(mocker):
+    resp = DummyResponse(200, {"articles": [{"title": "a"}], "total": 1})
+    session = SimpleNamespace(get=mocker.Mock(return_value=DummyContext(resp)))
+    mocker.patch("aiohttp.ClientSession", return_value=DummyContext(session))
+    result = await gdelt_v2.query_doc("test")
+    assert result.articles[0]["title"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_get_entities_retry(mocker):
+    resp1 = DummyResponse(429, {}, {"Retry-After": "1"})
+    resp2 = DummyResponse(200, {"entities": [{"name": "x"}]})
+    session = SimpleNamespace(get=mocker.Mock(side_effect=[DummyContext(resp1), DummyContext(resp2)]))
+    mocker.patch("aiohttp.ClientSession", return_value=DummyContext(session))
+    result = await gdelt_v3.get_entities("s", "e", "q")
+    assert result.entities[0]["name"] == "x"
+

--- a/tools.py
+++ b/tools.py
@@ -1,19 +1,19 @@
 import os
+import asyncio
 
 from smolagents import tool, Tool
 from pinecone import Pinecone
 from langchain_openai import OpenAIEmbeddings
-from langchain_core.documents import Document
 from langchain.agents import load_tools
 from langchain_community.tools.yahoo_finance_news import YahooFinanceNewsTool
 
+from gdelt_v2 import query_doc, query_gkg
+from gdelt_v3 import get_entities, get_events
 
 pc = Pinecone(api_key=os.getenv("PINECONE_API_KEY"))
 index = pc.Index(os.getenv("PINECONE_INDEX_NAME"))
 embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
 namespace = os.getenv("PINECONE_NAMESPACE")
-
-
 
 
 @tool
@@ -24,7 +24,7 @@ def ai_policy_geopolitics_semantic_search(
     """
     Use this tool to search curated newsletters by thought-leaders in the fields of AI, Policy, Geopolitics, and Security.
     This is a tool that returns a list of langchain documents that are semantically similar to the query.
-    
+
     Args:
         query: The query to search for.
         k: The number of documents to return.
@@ -33,11 +33,11 @@ def ai_policy_geopolitics_semantic_search(
         namespace=namespace,
         vector=embeddings.embed_query(query),
         top_k=k,
-        include_metadata=True
+        include_metadata=True,
     )
     formatted_results = []
-    for match in response['matches']:
-        metadata = match['metadata']
+    for match in response["matches"]:
+        metadata = match["metadata"]
         formatted_results.append(
             f"Title: {metadata['title']}\n"
             f"Author: {metadata['author']}\n"
@@ -54,7 +54,7 @@ def yahoo_finance_search(company_ticker: str) -> str:
     """
     Use this tool to search for financial data for publicly traded companies.
     Input must be a ticker symbol.
-    
+
     Args:
         company_ticker: The ticker of the company to search for. Example: "AAPL".
     """
@@ -62,5 +62,63 @@ def yahoo_finance_search(company_ticker: str) -> str:
     return tool.invoke(company_ticker)
 
 
-# Arxive Tool
+# Arxiv Tool
 arxiv_tool = Tool.from_langchain(load_tools(["arxiv"])[0])
+
+
+@tool
+def query_gdelt_v2_doc(
+    query: str,
+    mode: str = "TimelineTone",
+    start: str | None = None,
+    end: str | None = None,
+) -> dict:
+    """
+    Use this tool to query the GDELT V2 Full-Text API for articles related to the search query.
+
+    Args:
+        query: The search query to run.
+        mode: Timeline mode for the API. Defaults to "TimelineTone".
+        start: Optional start datetime in YYYYMMDDhhmmss format.
+        end: Optional end datetime in YYYYMMDDhhmmss format.
+    """
+    return asyncio.run(query_doc(query=query, mode=mode, start=start, end=end)).__dict__
+
+
+@tool
+def query_gdelt_v2_gkg(query: str, themes: list[str] | None = None) -> dict:
+    """
+    Use this tool to query the GDELT V2 GKG API. It returns Global Knowledge Graph records matching the query.
+
+    Args:
+        query: The search query to run.
+        themes: Optional list of themes to filter results.
+    """
+    return asyncio.run(query_gkg(query=query, themes=themes)).__dict__
+
+
+@tool
+def query_gdelt_v3_entities(start: str, end: str, query: str) -> dict:
+    """
+    Use this tool to query the experimental GDELT V3 entities API. It returns entities found in the specified time range.
+
+    Args:
+        start: Start datetime in YYYYMMDDhhmmss format.
+        end: End datetime in YYYYMMDDhhmmss format.
+        query: The search query to run.
+    """
+    return asyncio.run(get_entities(start=start, end=end, query=query)).__dict__
+
+
+@tool
+def query_gdelt_v3_events(start: str, end: str, query: str) -> dict:
+    """
+    Use this tool to query the experimental GDELT V3 events API. It returns events in the specified time range.
+
+    Args:
+        start: Start datetime in YYYYMMDDhhmmss format.
+        end: End datetime in YYYYMMDDhhmmss format.
+        query: The search query to run.
+    """
+    return asyncio.run(get_events(start=start, end=end, query=query)).__dict__
+


### PR DESCRIPTION
## Summary
- add asynchronous wrappers `gdelt_v2.py` and `gdelt_v3.py` with rate limiting
- expose new tool functions in `tools.py`
- document GDELT tools in `TOOLS.md` and update README with examples
- add dependencies for aiohttp, tenacity and testing
- implement unit tests for API wrappers
- restore the detailed tool docstrings
- ensure agent names are unique by renaming web search agent

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844a6336c10832cb6dad8c9bdda4df4