### PR TITLE
Fix duplicate web_search agent name

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ new_agent = CustomToolCallingAgent(
 manager_agent = CodeAgent(
     tools=[],
     model=claude_llm,
-    managed_agents=[web_search_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent, new_agent],
+    managed_agents=[search_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent, new_agent],
     additional_authorized_imports=["time", "numpy", "pandas"],
     planning_interval=2
 )

--- a/agent.py
+++ b/agent.py
@@ -46,10 +46,11 @@ claude_llm = LiteLLMModel(
 
 
 # Tool Calling Agents
-web_search_agent = CustomToolCallingAgent(
+search_agent = CustomToolCallingAgent(
     tools=[DuckDuckGoSearchTool(), VisitWebpageTool()],
     model=claude_llm,
     max_steps=5,
+    # Use a unique name to avoid conflicts with the `web_search` tool
     name="web_search_agent",
     description="Runs web searches for you. Give it your query as an argument."
 )
@@ -83,7 +84,7 @@ yahoo_finance_agent = CustomToolCallingAgent(
 manager_agent = CodeAgent(
     tools=[],
     model=claude_llm,
-    managed_agents=[web_search_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent],
+    managed_agents=[search_agent, newsletter_agent, arxiv_agent, yahoo_finance_agent],
     additional_authorized_imports=["time", "numpy", "pandas"],
     planning_interval=2
 )


### PR DESCRIPTION
## Summary
- rename `web_search_agent` variable to `search_agent`
- update manager agent to use `search_agent`
- update README snippet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880ef5807c832c92694f15c3995341